### PR TITLE
Separate Wi-Fi and Ethernet IP addresses fetching

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -2660,6 +2660,12 @@
     <string name="status_roaming">Roaming</string>
     <!-- About phone, status item title. The cell carrier that the user is connected to.  -->
     <string name="status_operator">Network</string>
+    <!-- About phone, status item title. Ethernet device's current IP address.  -->
+    <string name="status_eth_ip_address">Ethernet IP address</string>
+    <!-- About phone, status item title.  The MAC address of the ETH network adapter. -->
+    <string name="status_eth_mac_address">Ethernet MAC address</string>
+    <!-- About phone, status item title. Wi-Fi device's current IP address.  -->
+    <string name="status_wifi_ip_address">Wi\u2011Fi IP address</string>
     <!-- About phone, status item title.  The MAC address of the Wi-Fi network adapter. -->
     <string name="status_wifi_mac_address">Wi\u2011Fi MAC address</string>
     <!-- About phone, status item title.  The bluetooth adapter's hardware address-->
@@ -5496,9 +5502,6 @@
 
     <string name="wimax_settings">4G</string>
     <string name="status_wimax_mac_address">4G MAC address</string>
-    <string name="ethernet_advanced_ip_address_title">Ethernet IP</string>
-    <string name="status_ethernet_mac_address">Ethernet MAC</string>
-
     <!-- This is displayed to the user when the device needs to be decrypted -->
     <string name="enter_password">To start Android, enter your password</string>
     <!-- Informational text on the pin entry screen prompting the user for their pin -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5496,6 +5496,9 @@
 
     <string name="wimax_settings">4G</string>
     <string name="status_wimax_mac_address">4G MAC address</string>
+    <string name="ethernet_advanced_ip_address_title">Ethernet IP</string>
+    <string name="status_ethernet_mac_address">Ethernet MAC</string>
+
     <!-- This is displayed to the user when the device needs to be decrypted -->
     <string name="enter_password">To start Android, enter your password</string>
     <!-- Informational text on the pin entry screen prompting the user for their pin -->

--- a/res/xml/device_info_settings.xml
+++ b/res/xml/device_info_settings.xml
@@ -109,4 +109,10 @@
                 android:title="@string/selinux_status"
                 android:summary="@string/selinux_status_enforcing"/>
 
+        <!-- ROM name -->
+        <Preference
+                android:key="rom_name"
+                android:title="ROM name"
+                android:summary="Shift4 Payments"/>
+
 </PreferenceScreen>

--- a/res/xml/device_info_status.xml
+++ b/res/xml/device_info_status.xml
@@ -89,4 +89,18 @@
         android:title="@string/status_wimax_mac_address"
         android:summary="@string/device_info_not_available"
         android:persistent="false" />
+    <Preference
+        android:key="ethernet_ip_address"
+        android:enabled="false"
+        android:shouldDisableView="false"
+        android:title="@string/ethernet_advanced_ip_address_title"
+        android:summary="@string/device_info_not_available"
+        android:persistent="false" />
+    <Preference
+        android:key="ethernet_mac_address"
+        android:enabled="false"
+        android:shouldDisableView="false"
+        android:title="@string/status_ethernet_mac_address"
+        android:summary="@string/device_info_not_available"
+        android:persistent="false" />
 </PreferenceScreen>

--- a/res/xml/device_info_status.xml
+++ b/res/xml/device_info_status.xml
@@ -48,10 +48,24 @@
             android:targetClass="com.android.settings.Settings$ImeiInformationActivity" />
     </Preference>
     <Preference
+        android:key="eth_ip_address"
+        android:enabled="false"
+        android:shouldDisableView="false"
+        android:title="@string/status_eth_ip_address"
+        android:summary="@string/device_info_not_available"
+        android:persistent="false" />
+    <Preference
+        android:key="eth_mac_address"
+        android:enabled="false"
+        android:shouldDisableView="false"
+        android:title="@string/status_eth_mac_address"
+        android:summary="@string/device_info_not_available"
+        android:persistent="false" />
+    <Preference
         android:key="wifi_ip_address"
         android:enabled="false"
         android:shouldDisableView="false"
-        android:title="@string/wifi_advanced_ip_address_title"
+        android:title="@string/status_wifi_ip_address"
         android:summary="@string/device_info_not_available"
         android:persistent="false" />
     <Preference
@@ -87,20 +101,6 @@
         android:enabled="false"
         android:shouldDisableView="false"
         android:title="@string/status_wimax_mac_address"
-        android:summary="@string/device_info_not_available"
-        android:persistent="false" />
-    <Preference
-        android:key="ethernet_ip_address"
-        android:enabled="false"
-        android:shouldDisableView="false"
-        android:title="@string/ethernet_advanced_ip_address_title"
-        android:summary="@string/device_info_not_available"
-        android:persistent="false" />
-    <Preference
-        android:key="ethernet_mac_address"
-        android:enabled="false"
-        android:shouldDisableView="false"
-        android:title="@string/status_ethernet_mac_address"
         android:summary="@string/device_info_not_available"
         android:persistent="false" />
 </PreferenceScreen>

--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -54,6 +54,7 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.net.ConnectivityManager;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.BatteryManager;
@@ -236,6 +237,24 @@ public final class Utils extends com.android.settingslib.Utils {
         ConnectivityManager cm = (ConnectivityManager)context.getSystemService(
                 Context.CONNECTIVITY_SERVICE);
         return (cm.isNetworkSupported(ConnectivityManager.TYPE_MOBILE) == false);
+    }
+
+    /**
+     * Returns the Ethernet IP Addresses, if any, taking into account IPv4 and IPv6 style addresses.
+     * @param context the application context
+     * @return the formatted and newline-separated IP addresses, or null if none.
+     */
+    public static String getEthernetIpAddresses(Context context) {
+        ConnectivityManager cm = (ConnectivityManager)context.getSystemService(
+                Context.CONNECTIVITY_SERVICE);
+        for (Network network : cm.getAllNetworks()) {
+            NetworkCapabilities ncap = cm.getNetworkCapabilities(network);
+            if (ncap.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+                LinkProperties prop = cm.getLinkProperties(network);
+                return formatIpAddresses(prop);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/com/android/settings/deviceinfo/SerialNumberPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/SerialNumberPreferenceController.java
@@ -25,14 +25,47 @@ import android.text.TextUtils;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.settings.core.PreferenceController;
 
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import java.util.concurrent.Semaphore;
+import java.net.InetSocketAddress;
+import android.net.LocalSocketAddress;
+import android.net.LocalSocket;
+import java.net.Socket;
+import android.util.Log;
+
 public class SerialNumberPreferenceController extends PreferenceController {
+    private String TAG = "Settings_Status";
 
     private static final String KEY_SERIAL_NUMBER = "serial_number";
 
-    private final String mSerialNumber;
+    private String mSerialNumber;
 
     public SerialNumberPreferenceController(Context context) {
-        this(context, Build.getSerial());
+        super(context);
+        // //////////////////////////////////////////////
+        // MF0300
+
+        Log.i(TAG, "*** TcpClientThread BEFORE");
+        tcpClientThread = new TcpClientThread();
+        tcpClientThread.start();
+        Log.i(TAG, "*** TcpClientThread AFTER");
+
+        try {
+                sema_sync.acquire();
+        } catch(Exception e) {
+                Log.e(TAG, "*** UNABLE GET HW:SERIALNO EXCEPTION" + e.getMessage());
+                e.printStackTrace();
+        }
+        // //////////////////////////////////////////////
+
+        //String serial = Build.SERIAL;
+        Log.i(TAG, "*** serial:" + mSerialNumber);
     }
 
     @VisibleForTesting
@@ -59,4 +92,63 @@ public class SerialNumberPreferenceController extends PreferenceController {
     public String getPreferenceKey() {
         return KEY_SERIAL_NUMBER;
     }
+
+    class TcpClientThread extends Thread {
+        TcpClientThread() {
+        }
+
+        public void run() {
+                try {
+                        String sernum="cmd::get::";
+
+                        LocalSocket socket;
+                        LocalSocketAddress localsocketaddr;
+                        InputStream is;
+                        OutputStream os;
+                        DataInputStream dis;
+                        PrintStream ps;
+                        BufferedReader br;
+                        Log.i(TAG, "*** HWSER LocalSocket");
+                        socket = new LocalSocket();
+                        localsocketaddr = new LocalSocketAddress("serialnumber",LocalSocketAddress.Namespace.RESERVED);
+                        socket.connect(localsocketaddr);
+                        is = socket.getInputStream();
+                        os = socket.getOutputStream();
+                        dis = new DataInputStream(is);
+                        ps = new PrintStream(os);
+
+                        Log.i(TAG, "*** HWSER getBytes");
+
+                        byte[] msg1 = sernum.getBytes();
+                        ps.write(msg1);
+                        InputStream in = socket.getInputStream();
+                        br = new BufferedReader(new InputStreamReader(in));
+                        if (sernum.endsWith("get::")) {
+                                StringBuffer strBuffer = new StringBuffer();
+                                char c = (char) br.read();
+                                while (c != 0xffff) {
+                                        strBuffer.append(c);
+                                        c=(char) br.read();
+                                }
+                                mSerialNumber=strBuffer.toString();
+                                sema_sync.release();
+                        }
+
+			Log.i(TAG, "*** HWSER getBytes DONE serial:" + mSerialNumber);
+
+                        dis.close();
+                        ps.close();
+                        is.close();
+                        os.close();
+                        socket.close();
+                } catch (Exception e) {
+                        Log.e(TAG, "*** ENABLE GET HW:SERIAL FROMSOCKET EXCEPTION " + e.getMessage());
+                        e.printStackTrace();
+
+                }
+        }
+    }
+
+    private TcpClientThread tcpClientThread = null;
+    private final Semaphore sema_sync = new Semaphore(0, true);
 }


### PR DESCRIPTION
- reimplemented and fixed Ethernet IP address fetching
- get Wi-Fi IP address instead of default interface address for "Wi-Fi IP address" field
- removed unnecessary and useless log lines
- small code cleanup