### PR TITLE
Disable changing lock when device is not provisioned.

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -331,8 +331,10 @@ public class SettingsActivity extends SettingsDrawerActivity
             launchSettingFragment(initialFragmentName, isSubSettings, intent);
         }
 
+        final boolean deviceProvisioned = Utils.isDeviceProvisioned(this);
         if (mIsShowingDashboard) {
-            findViewById(R.id.search_bar).setVisibility(View.VISIBLE);
+            findViewById(R.id.search_bar).setVisibility(
+                deviceProvisioned ? View.VISIBLE : View.INVISIBLE);
             findViewById(R.id.action_bar).setVisibility(View.GONE);
             Toolbar toolbar = findViewById(R.id.search_action_bar);
             toolbar.setOnClickListener(this);

--- a/src/com/android/settings/password/ChooseLockGeneric.java
+++ b/src/com/android/settings/password/ChooseLockGeneric.java
@@ -164,6 +164,11 @@ public class ChooseLockGeneric extends SettingsActivity {
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
+            final Activity activity = getActivity();
+            if (!Utils.isDeviceProvisioned(activity) && !canRunBeforeDeviceProvisioned()) {
+                activity.finish();
+                return;
+            }
 
             String chooseLockAction = getActivity().getIntent().getAction();
             mFingerprintManager = Utils.getFingerprintManagerOrNull(getActivity());
@@ -240,6 +245,10 @@ public class ChooseLockGeneric extends SettingsActivity {
                 }
             }
             addHeaderView();
+        }
+
+        protected boolean canRunBeforeDeviceProvisioned() {
+            return false;
         }
 
         protected void addHeaderView() {

--- a/src/com/android/settings/password/SetupChooseLockGeneric.java
+++ b/src/com/android/settings/password/SetupChooseLockGeneric.java
@@ -129,6 +129,11 @@ public class SetupChooseLockGeneric extends ChooseLockGeneric {
             return layout.onCreateRecyclerView(inflater, parent, savedInstanceState);
         }
 
+        @Override
+        protected boolean canRunBeforeDeviceProvisioned() {
+            return true;
+        }
+
         /***
          * Disables preferences that are less secure than required quality and shows only secure
          * screen lock options here.

--- a/tests/robotests/src/com/android/settings/SettingsActivityTest.java
+++ b/tests/robotests/src/com/android/settings/SettingsActivityTest.java
@@ -18,6 +18,7 @@ package com.android.settings;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -30,16 +31,21 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.content.Context;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.provider.Settings.Global;
+import android.view.View;
 import android.view.Menu;
 
 import com.android.settings.search.SearchActivity;
 import com.android.settings.testutils.FakeFeatureFactory;
 import com.android.settings.testutils.SettingsRobolectricTestRunner;
+import com.android.settings.testutils.shadow.SettingsShadowResources;
+import com.android.settings.testutils.shadow.SettingsShadowResourcesImpl;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +53,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
@@ -70,9 +77,38 @@ public class SettingsActivityTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-
+        mContext = RuntimeEnvironment.application;
         mActivity = spy(new SettingsActivity());
         doReturn(mBitmap).when(mActivity).getBitmapFromXmlResource(anyInt());
+    }
+
+    @Test
+    @Config(shadows = {
+        SettingsShadowResourcesImpl.class,
+        SettingsShadowResources.SettingsShadowTheme.class,
+    })
+    public void onCreate_deviceNotProvisioned_shouldDisableSearch() {
+        Global.putInt(mContext.getContentResolver(), Global.DEVICE_PROVISIONED, 0);
+        final Intent intent = new Intent(mContext, Settings.class);
+        final SettingsActivity activity =
+            Robolectric.buildActivity(SettingsActivity.class, intent).create(Bundle.EMPTY).get();
+
+        assertThat(activity.findViewById(R.id.search_bar).getVisibility())
+            .isEqualTo(View.INVISIBLE);
+    }
+
+    @Test
+    @Config(shadows = {
+        SettingsShadowResourcesImpl.class,
+        SettingsShadowResources.SettingsShadowTheme.class,
+    })
+    public void onCreate_deviceProvisioned_shouldEnableSearch() {
+        Global.putInt(mContext.getContentResolver(), Global.DEVICE_PROVISIONED, 1);
+        final Intent intent = new Intent(mContext, Settings.class);
+        final SettingsActivity activity =
+            Robolectric.buildActivity(SettingsActivity.class, intent).create(Bundle.EMPTY).get();
+
+        assertThat(activity.findViewById(R.id.search_bar).getVisibility()).isEqualTo(View.VISIBLE);
     }
 
     @Test

--- a/tests/robotests/src/com/android/settings/password/ChooseLockGenericTest.java
+++ b/tests/robotests/src/com/android/settings/password/ChooseLockGenericTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.settings.password;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.provider.Settings.Global;
+
+import com.android.settings.password.ChooseLockGeneric.ChooseLockGenericFragment;
+import com.android.settings.testutils.SettingsRobolectricTestRunner;
+import com.android.settings.testutils.shadow.SettingsShadowResources;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(SettingsRobolectricTestRunner.class)
+public class ChooseLockGenericTest {
+
+    @After
+    public void tearDown() {
+        Global.putInt(RuntimeEnvironment.application.getContentResolver(),
+            Global.DEVICE_PROVISIONED, 1);
+    }
+
+    @Test
+    @Config(shadows = SettingsShadowResources.SettingsShadowTheme.class)
+    public void onCreate_deviceNotProvisioned_shouldFinishActivity() {
+        final Context context = RuntimeEnvironment.application;
+        Global.putInt(context.getContentResolver(), Global.DEVICE_PROVISIONED, 0);
+        final Activity activity = mock(Activity.class);
+        when(activity.getContentResolver()).thenReturn(context.getContentResolver());
+        when(activity.getTheme()).thenReturn(context.getTheme());
+
+        final ChooseLockGenericFragment fragment = spy(new ChooseLockGenericFragment());
+        when(fragment.getActivity()).thenReturn(activity);
+        when(fragment.getArguments()).thenReturn(Bundle.EMPTY);
+
+        fragment.onCreate(Bundle.EMPTY);
+        verify(activity).finish();
+    }
+
+}


### PR DESCRIPTION
When the device is not yet provisioned and settings is launched:
- disable the entry point for changing device lock
- remove the search panel from settings home page
- remove the search menu

Bug: 110034419
Test: make RunSettingsRoboTests
Change-Id: Ieb7eb0e8699229ec0824ccc19d7b958ac44965a2
Merged-In: Ieb7eb0e8699229ec0824ccc19d7b958ac44965a2
(cherry picked from commit 770f4abf9de2bb7d74497cc4b5f6795023229ef2)