### PR TITLE
BrightnessLevelPreferenceController: work without VR service

### DIFF
--- a/src/com/android/settings/display/BrightnessLevelPreferenceController.java
+++ b/src/com/android/settings/display/BrightnessLevelPreferenceController.java
@@ -164,7 +164,7 @@ public class BrightnessLevelPreferenceController extends PreferenceController im
         try {
             return IVrManager.Stub.asInterface(ServiceManager.getService(Context.VR_SERVICE))
                     .getVrModeState();
-        } catch (RemoteException e) {
+        } catch (Exception e) {
             Log.e(TAG, "Failed to check vr mode!", e);
         }
         return false;


### PR DESCRIPTION
When VR service is disabled, BrightnessLevelPreferenceController gets
no VrManager, but it doesn't check this pointer, so NullPointerException
happens. To prevent it, catch any exceptions while quering VR state.